### PR TITLE
[feat] #14 통계 페이지 컴포넌트 수정 및 화면 레이아웃 구현

### DIFF
--- a/frontend/src/assets/styles/variables.css
+++ b/frontend/src/assets/styles/variables.css
@@ -41,6 +41,32 @@
     --surface-expense-card: rgba(216, 67, 67, 0.08);
     --surface-expense-softest: rgba(216, 67, 67, 0.04);
 
+    --stats-expense-active: #ffc107;
+    --stats-expense-inactive: #e0e0e0;
+    --stats-expense-food: #ff8a65;
+    --stats-expense-transport: #4fc3f7;
+    --stats-expense-shopping: #ba68c8;
+    --stats-expense-medical: #81c784;
+    --stats-expense-education: #64b5f6;
+    --stats-expense-leisure: #ffd54f;
+    --stats-expense-housing: #a1887f;
+    --stats-expense-other: #90a4ae;
+
+    --stats-income-active: #ffc107;
+    --stats-income-inactive: #e0e0e0;
+    --stats-income-salary: #2e7d32;
+    --stats-income-pocket-money: #ff8a65;
+    --stats-income-side: #26a69a;
+    --stats-income-interest: #42a5f5;
+    --stats-income-bonus: #ffca28;
+    --stats-income-dividend: #7e57c2;
+    --stats-income-point: #ffa726;
+    --stats-income-other: #b0bec5;
+
+    --stats-comparison-better: #1976d2;
+    --stats-comparison-worse: #d32f2f;
+    --stats-comparison-same: #9e9e9e;
+
     --radius-sm: 8px;
     --radius-md: 10px;
     --radius-lg: 12px;

--- a/frontend/src/components/layout/AppHeader.vue
+++ b/frontend/src/components/layout/AppHeader.vue
@@ -1,8 +1,10 @@
 <template>
     <header class="header">
+        <div class="header-inner">
         <div class="text-group">
             <div class="title">{{ title }}</div>
             <div class="desc">{{ desc }}</div>
+        </div>
         </div>
     </header>
 </template>
@@ -17,14 +19,19 @@ const props = defineProps({
 <style scoped>
 .header {
     background: var(--primary);
-    padding: 16px;
-
-    display: flex;
-    align-items: center;
 
     position: sticky;
     top: 0;
     z-index: 999;
+}
+
+.header-inner {
+    width: min(100%, 1280px);
+    margin: 0 auto;
+    padding: 16px;
+
+    display: flex;
+    align-items: center;
 }
 
 .text-group {
@@ -42,5 +49,17 @@ const props = defineProps({
 .desc {
     font-size: var(--font-size-12);
     color: var(--text-secondary);
+}
+
+@media (min-width: 768px) {
+    .header-inner {
+        padding: 16px 32px;
+    }
+}
+
+@media (min-width: 1280px) {
+    .header-inner {
+        padding: 16px 48px;
+    }
 }
 </style>

--- a/frontend/src/components/layout/BottomNav.vue
+++ b/frontend/src/components/layout/BottomNav.vue
@@ -1,10 +1,12 @@
 <template>
     <nav class="bottom-nav">
-        <BottomNavItem icon="🏠" label="홈"/>
-        <BottomNavItem icon="📊" label="통계"/>
-        <BottomNavItem icon="➕" label="기록 추가"/>
-        <BottomNavItem icon="📋" label="내역"/>
-        <BottomNavItem icon="⚙️" label="설정"/>
+        <div class="bottom-nav-inner">
+            <BottomNavItem icon="🏠" label="홈"/>
+            <BottomNavItem icon="📊" label="통계"/>
+            <BottomNavItem icon="➕" label="기록 추가"/>
+            <BottomNavItem icon="📋" label="내역"/>
+            <BottomNavItem icon="⚙️" label="설정"/>
+        </div>
     </nav>
 </template>
 
@@ -22,11 +24,29 @@ const route = useRoute()
     left: 0;
     right: 0;
 
-    height: 60px;
     background: var(--white);
     border-top: 1px solid var(--border);
+}
+
+.bottom-nav-inner {
+    width: min(100%, 1280px);
+    height: 60px;
+    margin: 0 auto;
+    padding: 0 8px;
 
     display: flex;
     align-items: center;
+}
+
+@media (min-width: 768px) {
+    .bottom-nav-inner {
+        padding: 0 24px;
+    }
+}
+
+@media (min-width: 1280px) {
+    .bottom-nav-inner {
+        padding: 0 40px;
+    }
 }
 </style>

--- a/frontend/src/components/statistics/StatisticsBarCard.vue
+++ b/frontend/src/components/statistics/StatisticsBarCard.vue
@@ -1,16 +1,18 @@
 <template>
   <Card class="stats-card">
-    <h2 class="section-title">월별 지출 추이</h2>
-    <div
-      v-for="item in items"
-      :key="item.label"
-      class="bar-row"
-    >
-      <span class="bar-label" :class="{ active: item.active }">{{ item.label }}</span>
-      <div class="bar-track">
-        <div class="bar-fill" :style="{ width: `${item.width}%`, background: item.color }" />
+    <h2 class="section-title">{{ title }}</h2>
+    <div class="bar-list">
+      <div
+        v-for="item in items"
+        :key="item.label"
+        class="bar-row"
+      >
+        <span class="bar-label" :class="{ active: item.active }">{{ item.label }}</span>
+        <div class="bar-track">
+          <div class="bar-fill" :style="{ width: `${item.width}%`, background: item.color }" />
+        </div>
+        <span class="bar-amount" :class="{ active: item.active }">{{ item.amount }}</span>
       </div>
-      <span class="bar-amount" :class="{ active: item.active }">{{ item.amount }}</span>
     </div>
   </Card>
 </template>
@@ -19,6 +21,10 @@
 import Card from '@/components/common/Card.vue'
 
 defineProps({
+  title: {
+    type: String,
+    default: '월별 추이',
+  },
   items: {
     type: Array,
     default: () => [],
@@ -29,6 +35,8 @@ defineProps({
 <style scoped>
 .stats-card {
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .section-title {
@@ -36,6 +44,14 @@ defineProps({
   font-size: var(--font-size-15);
   font-weight: var(--font-weight-700);
   color: var(--text);
+}
+
+.bar-list {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 180px;
 }
 
 .bar-row {
@@ -72,6 +88,7 @@ defineProps({
 .bar-fill {
   height: 100%;
   border-radius: 9px;
+  min-width: 8px;
 }
 
 .bar-amount {
@@ -89,6 +106,10 @@ defineProps({
 }
 
 @media (min-width: 768px) {
+  .bar-list {
+    min-height: 220px;
+  }
+
   .bar-label {
     width: 44px;
     font-size: var(--font-size-12);

--- a/frontend/src/components/statistics/StatisticsComparisonCard.vue
+++ b/frontend/src/components/statistics/StatisticsComparisonCard.vue
@@ -6,8 +6,9 @@
       <div class="comp-values">
         <span class="comp-val prev">{{ item.previous }}</span>
         <span class="comp-arrow">→</span>
-        <span class="comp-val" :class="item.state">
-          {{ item.current }} {{ item.changeLabel }}
+        <span class="comp-current-group" :class="item.state">
+          <span class="comp-val current">{{ item.current }}</span>
+          <span v-if="item.changeLabel" class="comp-val change">{{ item.changeLabel }}</span>
         </span>
       </div>
     </div>
@@ -42,9 +43,10 @@ defineProps({
 }
 
 .comparison-row {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(64px, auto) max-content;
   align-items: center;
+  gap: 10px;
   padding: 10px 0;
   border-bottom: 1px solid var(--bg);
 }
@@ -56,12 +58,14 @@ defineProps({
 .comp-label {
   font-size: var(--font-size-13);
   color: var(--text-muted);
+  min-width: 0;
 }
 
 .comp-values {
-  display: flex;
-  gap: 10px;
+  display: grid;
+  grid-template-columns: minmax(88px, max-content) 16px max-content;
   align-items: center;
+  gap: 8px;
 }
 
 .comp-val {
@@ -70,28 +74,70 @@ defineProps({
   color: var(--text);
 }
 
-.comp-val.prev {
-  color: var(--text-subtle);
+.comp-current-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
 }
 
-.comp-val.better {
+.comp-current-group .comp-val {
+  white-space: nowrap;
+}
+
+.comp-current-group.better .comp-val {
   color: var(--income);
 }
 
-.comp-val.worse {
+.comp-current-group.worse .comp-val {
   color: var(--expense);
 }
 
-.comp-val.same {
+.comp-current-group.same .comp-val {
   color: var(--text);
+}
+
+.comp-val.current {
+  font-weight: var(--font-weight-700);
+}
+
+.comp-val.change {
+  text-align: left;
+}
+
+.comp-val.prev {
+  color: var(--text-subtle);
+  text-align: left;
 }
 
 .comp-arrow {
   font-size: var(--font-size-12);
   color: var(--border-muted);
+  text-align: center;
+}
+
+@media (max-width: 420px) {
+  .comparison-row {
+    grid-template-columns: minmax(56px, auto) minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .comp-values {
+    grid-template-columns: minmax(72px, auto) 16px minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 1279px) {
+  .comparison-row {
+    align-items: flex-start;
+  }
 }
 
 @media (min-width: 768px) {
+  .comp-values {
+    grid-template-columns: minmax(104px, max-content) 18px max-content;
+  }
+
   .comp-label,
   .comp-val {
     font-size: var(--font-size-14);
@@ -99,6 +145,14 @@ defineProps({
 }
 
 @media (min-width: 1280px) {
+  .comparison-row {
+    grid-template-columns: minmax(72px, auto) max-content;
+  }
+
+  .comp-values {
+    grid-template-columns: minmax(112px, max-content) 20px max-content;
+  }
+
   .section-title {
     font-size: var(--font-size-16);
   }

--- a/frontend/src/components/statistics/StatisticsComparisonCard.vue
+++ b/frontend/src/components/statistics/StatisticsComparisonCard.vue
@@ -5,7 +5,6 @@
       <span class="comp-label">{{ item.label }}</span>
       <div class="comp-values">
         <span class="comp-val prev">{{ item.previous }}</span>
-        <span class="comp-arrow">→</span>
         <span class="comp-current-group" :class="item.state">
           <span class="comp-val current">{{ item.current }}</span>
           <span v-if="item.changeLabel" class="comp-val change">{{ item.changeLabel }}</span>
@@ -44,7 +43,7 @@ defineProps({
 
 .comparison-row {
   display: grid;
-  grid-template-columns: minmax(64px, auto) max-content;
+  grid-template-columns: 88px minmax(0, 1fr);
   align-items: center;
   gap: 10px;
   padding: 10px 0;
@@ -58,14 +57,17 @@ defineProps({
 .comp-label {
   font-size: var(--font-size-13);
   color: var(--text-muted);
+  text-align: left;
   min-width: 0;
 }
 
 .comp-values {
   display: grid;
-  grid-template-columns: minmax(88px, max-content) 16px max-content;
+  grid-template-columns: 112px minmax(0, 1fr);
   align-items: center;
-  gap: 8px;
+  column-gap: 8px;
+  width: 100%;
+  min-width: 0;
 }
 
 .comp-val {
@@ -76,9 +78,15 @@ defineProps({
 
 .comp-current-group {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  min-width: 0;
+  text-align: right;
+  justify-self: end;
+  width: max-content;
+  max-width: 100%;
 }
 
 .comp-current-group .comp-val {
@@ -102,28 +110,23 @@ defineProps({
 }
 
 .comp-val.change {
-  text-align: left;
+  text-align: right;
 }
 
 .comp-val.prev {
   color: var(--text-subtle);
   text-align: left;
-}
-
-.comp-arrow {
-  font-size: var(--font-size-12);
-  color: var(--border-muted);
-  text-align: center;
+  min-width: 0;
 }
 
 @media (max-width: 420px) {
   .comparison-row {
-    grid-template-columns: minmax(56px, auto) minmax(0, 1fr);
+    grid-template-columns: 72px minmax(0, 1fr);
     align-items: flex-start;
   }
 
   .comp-values {
-    grid-template-columns: minmax(72px, auto) 16px minmax(0, 1fr);
+    grid-template-columns: 76px minmax(0, 1fr);
   }
 }
 
@@ -134,8 +137,18 @@ defineProps({
 }
 
 @media (min-width: 768px) {
+  .comparison-row {
+    grid-template-columns: 96px minmax(0, 1fr);
+  }
+
   .comp-values {
-    grid-template-columns: minmax(104px, max-content) 18px max-content;
+    grid-template-columns: 128px minmax(0, 1fr);
+  }
+
+  .comp-current-group {
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
   }
 
   .comp-label,
@@ -146,15 +159,15 @@ defineProps({
 
 @media (min-width: 1280px) {
   .comparison-row {
-    grid-template-columns: minmax(72px, auto) max-content;
-  }
-
-  .comp-values {
-    grid-template-columns: minmax(112px, max-content) 20px max-content;
+    grid-template-columns: 104px minmax(0, 1fr);
   }
 
   .section-title {
     font-size: var(--font-size-16);
+  }
+
+  .comp-values {
+    grid-template-columns: 136px minmax(0, 1fr);
   }
 
   .comp-label,

--- a/frontend/src/components/statistics/StatisticsComparisonCard.vue
+++ b/frontend/src/components/statistics/StatisticsComparisonCard.vue
@@ -1,6 +1,6 @@
 <template>
   <Card class="stats-card">
-    <h2 class="section-title">전월 비교</h2>
+    <h2 class="section-title">{{ title }}</h2>
     <div v-for="item in items" :key="item.label" class="comparison-row">
       <span class="comp-label">{{ item.label }}</span>
       <div class="comp-values">
@@ -18,6 +18,10 @@
 import Card from '@/components/common/Card.vue'
 
 defineProps({
+  title: {
+    type: String,
+    default: '전월 비교',
+  },
   items: {
     type: Array,
     default: () => [],

--- a/frontend/src/components/statistics/StatisticsMonthSelector.vue
+++ b/frontend/src/components/statistics/StatisticsMonthSelector.vue
@@ -22,7 +22,6 @@ defineEmits(['prev', 'next'])
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-top: 12px;
 }
 
 .month-btn {
@@ -37,11 +36,20 @@ defineEmits(['prev', 'next'])
   align-items: center;
   justify-content: center;
   font-size: var(--font-size-14);
+  line-height: 1;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.month-btn:hover {
+  border-color: var(--primary);
+  background: var(--surface-highlight);
 }
 
 .month-label {
   font-size: var(--font-size-14);
   font-weight: var(--font-weight-500);
   color: var(--text);
+  min-width: 92px;
+  text-align: center;
 }
 </style>

--- a/frontend/src/components/statistics/StatisticsMonthSelector.vue
+++ b/frontend/src/components/statistics/StatisticsMonthSelector.vue
@@ -1,12 +1,32 @@
 <template>
   <div class="month-selector">
-    <button class="month-btn" type="button" aria-label="이전 달" @click="$emit('prev')">‹</button>
+    <Button
+      class="month-btn"
+      variant="gray"
+      size="sm"
+      type="button"
+      aria-label="이전 달"
+      @click="$emit('prev')"
+    >
+      ‹
+    </Button>
     <span class="month-label">{{ label }}</span>
-    <button class="month-btn" type="button" aria-label="다음 달" @click="$emit('next')">›</button>
+    <Button
+      class="month-btn"
+      variant="gray"
+      size="sm"
+      type="button"
+      aria-label="다음 달"
+      @click="$emit('next')"
+    >
+      ›
+    </Button>
   </div>
 </template>
 
 <script setup>
+import Button from '@/components/common/Button.vue'
+
 defineProps({
   label: {
     type: String,
@@ -31,10 +51,8 @@ defineEmits(['prev', 'next'])
   border-radius: var(--radius-sm);
   background: var(--white);
   color: var(--text);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  min-height: 28px;
+  padding: 0;
   font-size: var(--font-size-14);
   line-height: 1;
   transition: border-color 0.2s ease, background-color 0.2s ease;

--- a/frontend/src/components/statistics/StatisticsPieCard.vue
+++ b/frontend/src/components/statistics/StatisticsPieCard.vue
@@ -1,30 +1,26 @@
 <template>
   <Card class="stats-card">
-    <h2 class="section-title">카테고리 비율</h2>
+    <h2 class="section-title">{{ title }}</h2>
     <div class="pie-inner">
       <svg class="chart" width="100" height="100" viewBox="0 0 100 100" aria-label="카테고리 비율 차트">
         <circle cx="50" cy="50" r="35" fill="none" :stroke="baseStroke" stroke-width="16" />
-        <circle
+        <path
           v-for="segment in segments"
           :key="segment.label"
-          cx="50"
-          cy="50"
-          r="35"
+          :d="segment.path"
           fill="none"
           :stroke="segment.color"
           stroke-width="16"
-          :stroke-dasharray="segment.dashArray"
-          :stroke-dashoffset="segment.dashOffset"
-          transform="rotate(-90 50 50)"
+          stroke-linecap="butt"
         />
         <text x="50" y="47" text-anchor="middle" class="amount">{{ totalAmount }}</text>
-        <text x="50" y="60" text-anchor="middle" class="caption">총 지출</text>
+        <text x="50" y="60" text-anchor="middle" class="caption">{{ centerLabel }}</text>
       </svg>
 
       <div class="pie-legend">
         <div v-for="item in items" :key="item.label" class="legend-item">
           <span class="legend-dot" :style="{ background: item.color }" />
-          <span>{{ item.label }}</span>
+          <span class="legend-label">{{ item.label }}</span>
           <span class="legend-pct">{{ item.percent }}%</span>
         </div>
       </div>
@@ -37,6 +33,14 @@ import { computed } from 'vue'
 import Card from '@/components/common/Card.vue'
 
 const props = defineProps({
+  title: {
+    type: String,
+    default: '카테고리 비율',
+  },
+  centerLabel: {
+    type: String,
+    default: '합계',
+  },
   totalAmount: {
     type: String,
     required: true,
@@ -48,27 +52,52 @@ const props = defineProps({
 })
 
 const baseStroke = 'var(--surface-muted)'
-const circumference = 2 * Math.PI * 35
+const center = 50
+const radius = 35
+
+function polarToCartesian(angleInDegrees) {
+  const angleInRadians = ((angleInDegrees - 90) * Math.PI) / 180
+
+  return {
+    x: center + radius * Math.cos(angleInRadians),
+    y: center + radius * Math.sin(angleInRadians),
+  }
+}
+
+function createArcPath(startAngle, endAngle) {
+  const start = polarToCartesian(endAngle)
+  const end = polarToCartesian(startAngle)
+  const largeArcFlag = endAngle - startAngle > 180 ? 1 : 0
+
+  return [
+    `M ${start.x} ${start.y}`,
+    `A ${radius} ${radius} 0 ${largeArcFlag} 0 ${end.x} ${end.y}`,
+  ].join(' ')
+}
 
 const segments = computed(() => {
-  let offset = 0
+  let startAngle = 0
+
   return props.items.map((item) => {
-    const arc = (item.percent / 100) * circumference
+    const angle = (item.percent / 100) * 360
+    const endAngle = startAngle + angle
     const segment = {
       label: item.label,
       color: item.color,
-      dashArray: `${arc} ${circumference - arc}`,
-      dashOffset: -offset,
+      path: createArcPath(startAngle, endAngle),
     }
-    offset += arc
+
+    startAngle = endAngle
     return segment
-  })
+  }).filter((segment, index) => props.items[index]?.percent > 0)
 })
 </script>
 
 <style scoped>
 .stats-card {
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .section-title {
@@ -81,11 +110,19 @@ const segments = computed(() => {
 .pie-inner {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 16px;
+  flex: 1;
+  min-height: 180px;
+}
+
+.chart {
+  flex-shrink: 0;
 }
 
 .pie-legend {
   flex: 1;
+  min-width: 0;
 }
 
 .legend-item {
@@ -104,24 +141,35 @@ const segments = computed(() => {
   flex-shrink: 0;
 }
 
+.legend-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .legend-pct {
   margin-left: auto;
   font-weight: var(--font-weight-700);
   color: var(--text);
+  font-size: var(--font-size-12);
 }
 
 .amount {
-  font-size: var(--font-size-12);
+  font-size: 11px;
   font-weight: var(--font-weight-700);
   fill: var(--text);
 }
 
 .caption {
-  font-size: var(--font-size-12);
+  font-size: 9px;
   fill: var(--text-muted);
 }
 
 @media (min-width: 768px) {
+  .pie-inner {
+    min-height: 220px;
+  }
+
   .legend-item {
     font-size: var(--font-size-13);
   }
@@ -135,6 +183,21 @@ const segments = computed(() => {
   .legend-item {
     font-size: var(--font-size-14);
     margin-bottom: 9px;
+  }
+}
+
+@media (max-width: 359px) {
+  .pie-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .chart {
+    align-self: center;
+  }
+
+  .pie-legend {
+    width: 100%;
   }
 }
 </style>

--- a/frontend/src/components/statistics/StatisticsSection.vue
+++ b/frontend/src/components/statistics/StatisticsSection.vue
@@ -1,0 +1,98 @@
+<template>
+  <section class="stats-section">
+    <div class="section-copy">
+      <h2 class="section-heading">{{ section.heading }}</h2>
+      <p v-if="section.description" class="section-description">{{ section.description }}</p>
+    </div>
+
+    <div class="stats-grid">
+      <StatisticsPieCard
+        :title="pieTitle"
+        :center-label="section.summaryLabel"
+        :total-amount="section.pie.totalAmount"
+        :items="section.pie.items"
+      />
+      <StatisticsBarCard
+        :title="`${sectionName} 월별 추이`"
+        :items="section.bars"
+      />
+      <StatisticsComparisonCard
+        :title="`${sectionName} 전월 비교`"
+        :items="section.comparison"
+      />
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import StatisticsBarCard from '@/components/statistics/StatisticsBarCard.vue'
+import StatisticsComparisonCard from '@/components/statistics/StatisticsComparisonCard.vue'
+import StatisticsPieCard from '@/components/statistics/StatisticsPieCard.vue'
+
+const props = defineProps({
+  section: {
+    type: Object,
+    required: true,
+  },
+})
+
+const sectionName = computed(() => props.section.heading.replace(' 통계', ''))
+const pieTitle = computed(() => `이달의 ${sectionName.value} 카테고리 비율`)
+</script>
+
+<style scoped>
+.stats-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.section-heading {
+  margin: 0;
+  font-size: var(--font-size-18);
+  font-weight: var(--font-weight-700);
+  color: var(--text);
+}
+
+.section-description {
+  margin: 0;
+  font-size: var(--font-size-13);
+  color: var(--text-muted);
+}
+
+.stats-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .stats-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 20px;
+  }
+
+  .section-heading {
+    font-size: var(--font-size-20);
+  }
+
+  .section-description {
+    font-size: var(--font-size-14);
+  }
+}
+</style>

--- a/frontend/src/components/statistics/StatisticsSection.vue
+++ b/frontend/src/components/statistics/StatisticsSection.vue
@@ -7,17 +7,17 @@
 
     <div class="stats-grid">
       <StatisticsPieCard
-        :title="pieTitle"
+        :title="section.titles.pie"
         :center-label="section.summaryLabel"
         :total-amount="section.pie.totalAmount"
         :items="section.pie.items"
       />
       <StatisticsBarCard
-        :title="`${sectionName} 월별 추이`"
+        :title="section.titles.bar"
         :items="section.bars"
       />
       <StatisticsComparisonCard
-        :title="`${sectionName} 전월 비교`"
+        :title="section.titles.comparison"
         :items="section.comparison"
       />
     </div>
@@ -25,7 +25,6 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
 import StatisticsBarCard from '@/components/statistics/StatisticsBarCard.vue'
 import StatisticsComparisonCard from '@/components/statistics/StatisticsComparisonCard.vue'
 import StatisticsPieCard from '@/components/statistics/StatisticsPieCard.vue'
@@ -36,9 +35,6 @@ const props = defineProps({
     required: true,
   },
 })
-
-const sectionName = computed(() => props.section.heading.replace(' 통계', ''))
-const pieTitle = computed(() => `이달의 ${sectionName.value} 카테고리 비율`)
 </script>
 
 <style scoped>

--- a/frontend/src/pages/Statistics.vue
+++ b/frontend/src/pages/Statistics.vue
@@ -1,0 +1,71 @@
+<template>
+  <LayoutWrapper title="통계" desc="월별 소비 흐름과 전월 비교를 확인해보세요">
+    <div class="stats-body">
+      <StatisticsMonthSelector
+        :label="statistics.monthLabel"
+        @prev="moveMonth(-1)"
+        @next="moveMonth(1)"
+      />
+
+      <p v-if="errorMessage" class="feedback error">{{ errorMessage }}</p>
+      <p v-else-if="isLoading" class="feedback">통계 데이터를 불러오는 중입니다.</p>
+
+      <div v-else class="stats-sections">
+        <StatisticsSection
+          v-for="section in statistics.sections"
+          :key="section.key"
+          :section="section"
+        />
+      </div>
+    </div>
+  </LayoutWrapper>
+</template>
+
+<script setup>
+import LayoutWrapper from '@/components/layout/LayoutWrapper.vue'
+import StatisticsMonthSelector from '@/components/statistics/StatisticsMonthSelector.vue'
+import StatisticsSection from '@/components/statistics/StatisticsSection.vue'
+import { useStatisticsPage } from '@/composables/useStatisticsPage'
+
+const { errorMessage, isLoading, moveMonth, statistics } = useStatisticsPage()
+</script>
+
+<style scoped>
+.stats-body {
+  width: min(100%, 1280px);
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.feedback {
+  margin: 16px 0 0;
+  color: var(--text-muted);
+}
+
+.feedback.error {
+  color: var(--expense);
+}
+
+.stats-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  margin-top: 16px;
+}
+
+@media (min-width: 768px) {
+  .stats-body {
+    padding: 20px 32px;
+  }
+
+  .stats-sections {
+    gap: 32px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .stats-body {
+    padding: 24px 48px;
+  }
+}
+</style>


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #14 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

통계 페이지 UI와 레이아웃을 구성했습니다.
통계 섹션을 StatisticsSection 컴포넌트로 분리해 페이지 구조를 정리했습니다.
지출/수입 통계 카드 레이아웃을 반응형에 맞게 조정했습니다.
통계 색상 토큰을 정리하고 카드 UI 스타일을 다듬었습니다.
전월 비교 카드의 정렬 및 반응형 레이아웃을 수정했습니다.

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

npm run build 통과
통계 페이지 UI 수동 확인 완료
모바일 / 태블릿 / 데스크톱 반응형 레이아웃 확인

## 📸 스크린샷
> 필요시 스크린샷을 첨부해주세요.
<img width="1433" height="776" alt="스크린샷 2026-04-09 오후 1 39 59" src="https://github.com/user-attachments/assets/88227d5b-a06c-4bcb-9f11-7aac3188b0a9" />
<img width="1425" height="779" alt="스크린샷 2026-04-09 오후 1 40 05" src="https://github.com/user-attachments/assets/aa3df44b-b65f-41d1-a15f-b06372d875c2" />



## 📎 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.


이번 PR은 통계 페이지의 화면 UI 및 레이아웃 구성에만 집중했습니다.
useStatisticsPage.js와 statistics.js를 포함한 데이터 로직 정리는 별도 PR에서 진행할 예정입니다.
현재 통계 데이터는 mock 기반으로 동작합니다.