### PR TITLE
[feat] #25 카테고리 아이콘 공통 컴포넌트 구현

### DIFF
--- a/frontend/src/assets/images/category-icons/default.svg
+++ b/frontend/src/assets/images/category-icons/default.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#f8fafc"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">📁</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/expense-education.svg
+++ b/frontend/src/assets/images/category-icons/expense-education.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#f5f3ff"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">📚</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/expense-etc.svg
+++ b/frontend/src/assets/images/category-icons/expense-etc.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#f8fafc"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">📦</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/expense-food.svg
+++ b/frontend/src/assets/images/category-icons/expense-food.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#fff7ed"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">🍔</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/expense-home.svg
+++ b/frontend/src/assets/images/category-icons/expense-home.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#f0fdf4"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">🏠</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/expense-leisure.svg
+++ b/frontend/src/assets/images/category-icons/expense-leisure.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#ecfeff"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">🎮</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/expense-medical.svg
+++ b/frontend/src/assets/images/category-icons/expense-medical.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#fef2f2"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">💊</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/expense-shopping.svg
+++ b/frontend/src/assets/images/category-icons/expense-shopping.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#fdf2f8"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">🛍️</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/expense-transport.svg
+++ b/frontend/src/assets/images/category-icons/expense-transport.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#eff6ff"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">🚌</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/income-allowance.svg
+++ b/frontend/src/assets/images/category-icons/income-allowance.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#fef2f2"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">🧧</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/income-bonus.svg
+++ b/frontend/src/assets/images/category-icons/income-bonus.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#fefce8"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">🎁</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/income-interest.svg
+++ b/frontend/src/assets/images/category-icons/income-interest.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#eff6ff"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">🏦</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/income-point.svg
+++ b/frontend/src/assets/images/category-icons/income-point.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#fffbeb"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">⭐</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/income-salary.svg
+++ b/frontend/src/assets/images/category-icons/income-salary.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#ecfdf5"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">💰</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/income-side.svg
+++ b/frontend/src/assets/images/category-icons/income-side.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#fff7ed"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">💵</text>
+</svg>

--- a/frontend/src/assets/images/category-icons/income-stock.svg
+++ b/frontend/src/assets/images/category-icons/income-stock.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="18" fill="#eef2ff"/>
+  <text x="32" y="40" text-anchor="middle" font-size="28">📈</text>
+</svg>

--- a/frontend/src/components/common/CategoryIcon.vue
+++ b/frontend/src/components/common/CategoryIcon.vue
@@ -1,0 +1,30 @@
+<template>
+  <img :src="src" :alt="alt" class="icon" />
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { getCategoryIconById } from '@/constants/categoryIconMap'
+
+const props = defineProps({
+  categoryId: {
+    type: String,
+    required: true,
+  },
+  alt: {
+    type: String,
+    default: 'category icon',
+  },
+})
+
+const src = computed(() => getCategoryIconById(props.categoryId))
+</script>
+
+<style scoped>
+.icon {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  display: block;
+}
+</style>

--- a/frontend/src/constants/categoryIconMap.js
+++ b/frontend/src/constants/categoryIconMap.js
@@ -1,0 +1,47 @@
+import defaultIcon from '@/assets/images/category-icons/default.svg'
+import expenseEducationIcon from '@/assets/images/category-icons/expense-education.svg'
+import expenseEtcIcon from '@/assets/images/category-icons/expense-etc.svg'
+import expenseFoodIcon from '@/assets/images/category-icons/expense-food.svg'
+import expenseHomeIcon from '@/assets/images/category-icons/expense-home.svg'
+import expenseLeisureIcon from '@/assets/images/category-icons/expense-leisure.svg'
+import expenseMedicalIcon from '@/assets/images/category-icons/expense-medical.svg'
+import expenseShoppingIcon from '@/assets/images/category-icons/expense-shopping.svg'
+import expenseTransportIcon from '@/assets/images/category-icons/expense-transport.svg'
+import incomeAllowanceIcon from '@/assets/images/category-icons/income-allowance.svg'
+import incomeBonusIcon from '@/assets/images/category-icons/income-bonus.svg'
+import incomeInterestIcon from '@/assets/images/category-icons/income-interest.svg'
+import incomePointIcon from '@/assets/images/category-icons/income-point.svg'
+import incomeSalaryIcon from '@/assets/images/category-icons/income-salary.svg'
+import incomeSideIcon from '@/assets/images/category-icons/income-side.svg'
+import incomeStockIcon from '@/assets/images/category-icons/income-stock.svg'
+
+export const CATEGORY_ICON_MAP = {
+  c001: expenseFoodIcon,
+  c002: expenseTransportIcon,
+  c003: expenseShoppingIcon,
+  c004: expenseMedicalIcon,
+  c005: expenseEducationIcon,
+  c006: expenseLeisureIcon,
+  c007: expenseHomeIcon,
+  c008: expenseEtcIcon,
+  c009: incomeSalaryIcon,
+  c010: incomeAllowanceIcon,
+  c011: incomeSideIcon,
+  c012: incomeInterestIcon,
+  c013: incomeBonusIcon,
+  c014: incomeStockIcon,
+  c015: incomePointIcon,
+  c016: expenseEtcIcon,
+  c101: incomeSalaryIcon,
+  c102: incomeAllowanceIcon,
+  c103: incomeSideIcon,
+  c104: incomeInterestIcon,
+  c105: incomeBonusIcon,
+  c106: incomeStockIcon,
+  c107: incomePointIcon,
+  c108: expenseEtcIcon,
+}
+
+export function getCategoryIconById(categoryId) {
+  return CATEGORY_ICON_MAP[categoryId] || defaultIcon
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #25 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

src/assets/images 폴더에 카테고리 아이콘 이미지를 category-icons폴더에 추가
constants/categoryIconMap.js --> 아이콘 이미지와 아이콘의 ID 연결
components/common/CategoryIcon.vue --> 카테고리 ID를 받아 ID에 맞는 아이콘 이미지를 찾아서 렌더링


## 🧪 테스트 결과
테스트 중인 AddPage에서 category.id로 불러오면 카테고리 이미지가 잘 등록 됩니다.



## 📸 스크린샷
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.