### PR TITLE
[fix] 거래 내역 페이지 필터 모바일 사이즈 반응형 적용, 금액순 정렬 로직 수정

### DIFF
--- a/frontend/src/components/transactions/TransactionFilterBar.vue
+++ b/frontend/src/components/transactions/TransactionFilterBar.vue
@@ -23,6 +23,7 @@
       <CategoryChip
         v-for="item in typeOptions"
         :key="item.value"
+        class="filter-chip type-chip"
         :label="item.label"
         :active="item.value === selectedType"
         :on-click="() => emit('update:selectedType', item.value)"
@@ -38,12 +39,14 @@
       </div>
 
       <CategoryChip
+        class="filter-chip"
         :label="categoryLabel"
         :active="isCategoryOpen || isCategoryActive"
         :on-click="() => emit('toggle-category')"
       />
 
       <CategoryChip
+        class="filter-chip"
         :label="dateLabel"
         :active="dateLabel !== '날짜'"
         :on-click="() => emit('open-date')"
@@ -185,5 +188,36 @@ function clearQuery() {
   font-size: var(--font-size-12);
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+@media (max-width: 767px) {
+  .filter-row {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    overflow: visible;
+    align-items: stretch;
+  }
+
+  .month-wrap {
+    min-width: 0;
+  }
+
+  .month-wrap :deep(.select) {
+    width: 100%;
+    min-width: 0;
+    padding: 8px 24px 8px 10px;
+    font-size: 11px;
+  }
+
+  .filter-row :deep(.chip) {
+    width: 100%;
+    min-width: 0;
+    justify-content: center;
+    padding: 8px 8px;
+    font-size: 11px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 </style>

--- a/frontend/src/components/transactions/TransactionSortBar.vue
+++ b/frontend/src/components/transactions/TransactionSortBar.vue
@@ -67,4 +67,27 @@ defineEmits(['update:selectedSort'])
 .sort-options::-webkit-scrollbar {
   display: none;
 }
+
+.sort-options :deep(.chip) {
+  white-space: nowrap;
+}
+
+@media (max-width: 767px) {
+  .sort-bar {
+    align-items: flex-start;
+  }
+
+  .sort-options {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    overflow: visible;
+    gap: 6px;
+  }
+
+  .sort-options :deep(.chip) {
+    font-size: 11px;
+    padding: 5px 9px;
+    line-height: 1.1;
+  }
+}
 </style>

--- a/frontend/src/pages/TransactionPage.vue
+++ b/frontend/src/pages/TransactionPage.vue
@@ -121,6 +121,7 @@ const transactionGroups = ref([])
 const visibleGroupCount = ref(PAGE_SIZE)
 const loadMoreSentinel = ref(null)
 let loadMoreObserver = null
+let lastScrollY = 0
 
 const dateFilter = ref({
   mode: 'single',
@@ -234,8 +235,20 @@ function openRecordDetail(recordId) {
   router.push(`/records/${recordId}`)
 }
 
+function handleWindowScroll() {
+  const currentY = window.scrollY || 0
+
+  if (isTransactionCategoryOpen.value && Math.abs(currentY - lastScrollY) > 2) {
+    isTransactionCategoryOpen.value = false
+  }
+
+  lastScrollY = currentY
+}
+
 onMounted(async () => {
   await fetchData()
+  lastScrollY = window.scrollY || 0
+  window.addEventListener('scroll', handleWindowScroll, { passive: true })
 
   if (typeof IntersectionObserver === 'undefined' || !loadMoreSentinel.value) {
     return
@@ -256,6 +269,8 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+  window.removeEventListener('scroll', handleWindowScroll)
+
   if (loadMoreObserver) {
     loadMoreObserver.disconnect()
   }

--- a/frontend/src/utils/transaction.js
+++ b/frontend/src/utils/transaction.js
@@ -123,19 +123,11 @@ export function sortTransactionGroups(groups, selectedSort) {
   }
 
   if (selectedSort === 'amountDesc') {
-    return copied.sort(
-      (a, b) =>
-        Math.max(...b.records.map((record) => record.amountValue)) -
-        Math.max(...a.records.map((record) => record.amountValue)),
-    )
+    return buildAmountSortedGroups(copied, 'desc')
   }
 
   if (selectedSort === 'amountAsc') {
-    return copied.sort(
-      (a, b) =>
-        Math.min(...a.records.map((record) => record.amountValue)) -
-        Math.min(...b.records.map((record) => record.amountValue)),
-    )
+    return buildAmountSortedGroups(copied, 'asc')
   }
 
   return copied
@@ -177,4 +169,36 @@ function sortTransactionRecords(records, selectedSort) {
   }
 
   return records
+}
+
+function buildAmountSortedGroups(groups, direction) {
+  const records = groups.flatMap((group) => group.records)
+  const sortedRecords = [...records].sort((a, b) => {
+    if (a.amountValue === b.amountValue) {
+      return b.dateOrder - a.dateOrder || b.time.localeCompare(a.time)
+    }
+
+    return direction === 'desc'
+      ? b.amountValue - a.amountValue
+      : a.amountValue - b.amountValue
+  }).map((record) => ({
+    ...record,
+    // 금액 정렬 모드에서는 날짜 그룹 헤더가 없으므로 카드 메타에 날짜를 함께 노출한다.
+    time: `${formatDateLabel(record.date)} · ${record.time}`,
+  }))
+
+  const signedTotal = sortedRecords.reduce(
+    (sum, record) => sum + (record.type === 'income' ? record.amountValue : -record.amountValue),
+    0,
+  )
+
+  return [
+    {
+      title: direction === 'desc' ? '금액 높은순' : '금액 낮은순',
+      records: sortedRecords,
+      totalAmountValue: signedTotal,
+      total: formatExactCurrency(signedTotal, signedTotal >= 0),
+      totalType: signedTotal >= 0 ? 'income' : 'expense',
+    },
+  ]
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

#17 
급한 작업이라 이슈 새로 파지 않고 '거래 내역 조회 기능 구현' 브랜치(feat/17-transaction-list-page)에서 작업했습니다.

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

모바일 화면 사이즈(390 x 844)에 반응형을 적용하여 보기 좋게 개선했습니다.

1. 거래 내역 필터 
- 이전: 거래 내역 필터 6개가 하나의 행에 위치해 한 눈에 다 보이지 않고 가로 스크롤 필요
- 이후: CSS 브레이크포인트 767px 적용하여 2행으로 나눠서 보이게 변경
  -  화면 너비 768px 이상: 기존처럼 한 줄(가로)
  - 화면 너비 767px 이하: 3열 그리드 2행 (1행: 전체 / 지출 / 수입, 2행: 월선택 / 카테고리 / 날짜)
  - 칩/셀렉트 폭을 100%로 맞춰 가로 스크롤 없이 표시
  - 긴 라벨은 칩 내부에서 ellipsis 처리
 
2. 거래 내역 정렬 칩
- 이전: 정렬 칩 내부 텍스트 줄바꿈 일어남
- 이후: 텍스트 줄바꿈 일어나지 않도록 변경
  - 칩에 white-space: nowrap 적용
  - 모바일에서 칩 폰트/패딩 축소
  - 필요 시 칩 자체는 다음 줄로 내려가도, 텍스트는 줄바꿈되지 않도록 처리

3. 거래 내역 카테고리 필터
- 이전: 카테고리 필터 클릭 시 인라인 카드 펼쳐지고, 닫히지 않은 채 자리 차지, 필터 한 번 더 클릭해야 닫힘
- 이후: 카테고리 필터가 열린 상태로 스크롤하면 자동으로 접히게 변경
  - window 스크롤 이벤트 리스너 추가
  - 스크롤 이동이 감지되면 isTransactionCategoryOpen = false
  - 컴포넌트 언마운트 시 이벤트 리스너 제거

4. 금액 높은순/낮은순 정렬 로직 수정
- 이전: 날짜 그룹이 묶여서 함께 나와 금액순 정렬이 깨짐
ex. 4/10 50만원 기록과 함께 500원 기록이 같은 날짜로 묶여 함께 나와 금액 높은순 정렬에 위배
- 이후: 날짜별 기록이 묶여서 함께 나오지 않고 금액 순으로만 정렬되도록 변경
  - 금액순 정렬 선택 시 날짜 그룹핑 해제
  - 전체 레코드를 금액 기준으로 전역 정렬
  - UI는 단일 섹션으로 렌더링해 순서 왜곡 제거

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷
> 필요시 스크린샷을 첨부해주세요.

### 이전
<img width="391" height="849" alt="image" src="https://github.com/user-attachments/assets/4968ce1a-f441-4aea-8386-1b6ef162ee3a" />
<img width="391" height="850" alt="image" src="https://github.com/user-attachments/assets/6ca12a57-2029-4f53-8988-3208c1486d58" />

### 이후
<img width="389" height="849" alt="image" src="https://github.com/user-attachments/assets/b3422a66-a431-464a-94d3-c22168f1fe28" />
<img width="388" height="848" alt="image" src="https://github.com/user-attachments/assets/22e44e57-ccb0-447b-977d-328e1b199ba0" />



## 📎 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.